### PR TITLE
Add org.vim.rst-file to to LSItemContentTypes

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -38,6 +38,7 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>net.sourceforge.docutils</string>
+				<string>org.vim.rst-file</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
I don't know if this is right, but it gets quicklook to use the qlrest
plugin when macvim is installed.

toland/qlmarkdown#3 looks like a related fix for a macvim markdown type
conflict.
