### PR TITLE
Unicode fix for recent OS X / Python / docutils

### DIFF
--- a/GeneratePreviewForURL.m
+++ b/GeneratePreviewForURL.m
@@ -13,7 +13,7 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
 							   CFDictionaryRef options)
 {
     // TODO: Fallback to plaintext rendering if rest rendering fails?
-	NSString *source = [NSString stringWithContentsOfFile:[url path] encoding:NSUTF8StringEncoding error:nil];
+	NSString *source = [NSString stringWithContentsOfFile:[(NSURL*)url path] encoding:NSUTF8StringEncoding error:nil];
 	CFDataRef data = (CFDataRef) renderRest(source);
 	CFStringRef uttype = kUTTypeHTML;
 	if (!data) {

--- a/GenerateThumbnailForURL.m
+++ b/GenerateThumbnailForURL.m
@@ -20,12 +20,12 @@ OSStatus GenerateThumbnailForURL(void *thisInterface,
 								 CFDictionaryRef options, CGSize maxSize)
 {
     // TODO: Fallback to plaintext rendering if rest rendering fails?
-	NSString *source = [NSString stringWithContentsOfFile:[url path] encoding:NSUTF8StringEncoding error:nil];
+	NSString *source = [NSString stringWithContentsOfFile:[(NSURL*)url path] encoding:NSUTF8StringEncoding error:nil];
 	NSData *data = renderRest(source);
 	NSString *mimetype = @"text/html";
 	
 	if (!data) {
-		data = (CFDataRef) [source dataUsingEncoding:NSUTF8StringEncoding];
+		data = [source dataUsingEncoding:NSUTF8StringEncoding];
 		mimetype = @"text/plain";
 	}
 	
@@ -36,11 +36,11 @@ OSStatus GenerateThumbnailForURL(void *thisInterface,
 						NSMakeSize((maxSize.width * (600.0/800.0)), 
 								   maxSize.height));
 
-        WebView* webView = [[[WebView alloc] initWithFrame: viewRect] autorelease];
+	WebView* webView = [[[WebView alloc] initWithFrame: viewRect] autorelease];
 	[webView scaleUnitSquareToSize: scaleSize];
 	[[[webView mainFrame] frameView] setAllowsScrolling:NO];
 	[[webView mainFrame] loadData: data
-						 MIMEType: @"text/html"
+						 MIMEType: mimetype
 				 textEncodingName: @"utf-8"
 						  baseURL: nil];
 

--- a/Info.plist
+++ b/Info.plist
@@ -2,32 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UTImportedTypeDeclarations</key>
-	<array>
-		<dict>
-			<key>UTTypeIdentifier</key>
-			<string>net.sourceforge.docutils</string>
-			<key>UTTypeReferenceURL</key>
-			<string>http://docutils.sourceforge.net</string>
-			<key>UTTypeDescription</key>
-			<string>ReStructured Text document</string>
-			<key>UTTypeIconFile</key>
-			<string>public.text.icns</string>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>public.text</string>
-				<string>public.plain-text</string>
-			</array>
-			<key>UTTypeTagSpecification</key>
-			<dict>
-				<key>public.filename-extension</key>
-				<array>
-					<string>rest</string>
-					<string>rst</string>
-				</array>
-			</dict>
-		</dict>
-	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleDocumentTypes</key>
@@ -44,17 +18,17 @@
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>net.pixane.qlgenerator.QLRest</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleVersion</key>
-	<string>2.0.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
 	<key>CFBundleShortVersionString</key>
+	<string>2.0.0</string>
+	<key>CFBundleVersion</key>
 	<string>2.0.0</string>
 	<key>CFPlugInDynamicRegisterFunction</key>
 	<string></string>
@@ -74,15 +48,41 @@
 	</dict>
 	<key>CFPlugInUnloadFunction</key>
 	<string></string>
-	<key>QLSupportsConcurrentRequests</key>
-	<false/>
 	<key>QLNeedsToBeRunInMainThread</key>
 	<true/>
-	<key>QLThumbnailMinimumSize</key>
-	<real>17</real>
-	<key>QLPreviewWidth</key>
-	<real>800</real>
 	<key>QLPreviewHeight</key>
 	<real>600</real>
+	<key>QLPreviewWidth</key>
+	<real>800</real>
+	<key>QLSupportsConcurrentRequests</key>
+	<false/>
+	<key>QLThumbnailMinimumSize</key>
+	<real>17</real>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.text</string>
+				<string>public.plain-text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>ReStructured Text document</string>
+			<key>UTTypeIconFile</key>
+			<string>public.text.icns</string>
+			<key>UTTypeIdentifier</key>
+			<string>net.sourceforge.docutils</string>
+			<key>UTTypeReferenceURL</key>
+			<string>http://docutils.sourceforge.net</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>rest</string>
+					<string>rst</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/QLRest.xcodeproj/project.pbxproj
+++ b/QLRest.xcodeproj/project.pbxproj
@@ -155,7 +155,7 @@
 		089C1669FE841209C02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0420;
+				LastUpgradeCheck = 0720;
 			};
 			buildConfigurationList = 2CA326220896AD4900168862 /* Build configuration list for PBXProject "QLRest" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -224,7 +224,7 @@
 		2CA3261F0896AD4900168862 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = G5;
@@ -233,6 +233,7 @@
 				HEADER_SEARCH_PATHS = "./discount-config";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = /Library/QuickLook;
+				PRODUCT_BUNDLE_IDENTIFIER = net.pixane.qlgenerator.QLRest;
 				PRODUCT_NAME = QLRest;
 				SDKROOT = macosx;
 				VALID_ARCHS = "i386 x86_64";
@@ -244,13 +245,14 @@
 		2CA326200896AD4900168862 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				HEADER_SEARCH_PATHS = "./discount-config";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = /Library/QuickLook;
+				PRODUCT_BUNDLE_IDENTIFIER = net.pixane.qlgenerator.QLRest;
 				PRODUCT_NAME = QLRest;
 				SDKROOT = macosx;
 				VALID_ARCHS = "i386 x86_64";
@@ -261,9 +263,11 @@
 		2CA326230896AD4900168862 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = QLRest;
 				SDKROOT = "";
 				WARNING_CFLAGS = "-Wall";
@@ -273,7 +277,6 @@
 		2CA326240896AD4900168862 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1)";
 				ARCHS_STANDARD_32_64_BIT_PRE_XCODE_3_1 = "ppc i386 ppc64 x86_64";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;

--- a/RestConverter.m
+++ b/RestConverter.m
@@ -46,6 +46,7 @@ NSData* renderRest(NSString* source) {
     if (pParts == NULL && PyErr_Occurred()) {
         PyObject *pErrType, *pErrValue, *pTraceback;
         PyErr_Fetch(&pErrType, &pErrValue, &pTraceback);
+
         if (pErrValue != NULL)
             html = [NSString stringWithFormat:@
                     "<html>"
@@ -77,6 +78,9 @@ NSData* renderRest(NSString* source) {
     pBody = PyDict_GetItemString(pParts, "html_body");
 
     if (pBody != NULL) {
+        char *body = PyString_AsString(PyUnicode_AsUTF8String(pBody));
+        Py_DECREF(pBody);
+
         NSString *styles = [NSString stringWithContentsOfFile:[[NSBundle bundleWithIdentifier: @"net.pixane.qlgenerator.QLRest"]
                                                                pathForResource:@"styles" ofType:@"css"]
                                                      encoding:NSUTF8StringEncoding
@@ -99,9 +103,7 @@ NSData* renderRest(NSString* source) {
                 "</div>"
                 "</body>"
                 "</html>",
-                styles, [NSString stringWithUTF8String:PyString_AsString(pBody)]];
-
-        Py_DECREF(pBody);
+                styles, [NSString stringWithUTF8String:body]];
 
         return [html dataUsingEncoding:NSUTF8StringEncoding];
     }


### PR DESCRIPTION
On Yosemite with system Python version 2.7.10 and latest docutils (0.12) installed, the result value that this plugin expected to be a `str` is now returned as `unicode`. Calling `PyString_AsString` on it returned a null C string and previews failed.

I'm not a Mac app developer, there may be better fixes or updates needed in other places, but this is the minimal fix that worked for me and got the plugin working again.
